### PR TITLE
Split deep_serialize function.

### DIFF
--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -298,38 +298,43 @@ defmodule PaperTrail do
     Map.drop(model, [:__struct__, :__meta__] ++ relationships)
   end
 
-  defp serialize_changes(data) do
+  defp serialize_changes(data), do: serialize_changes(data, true)
+  defp serialize_changes(data, is_root) do
     case is_map(data) do
       false -> data
-      true -> deep_serialize(data)
+      true -> deep_serialize(data, is_root)
     end
   end
 
-  defp deep_serialize(data) do
+  defp deep_serialize(data, is_root) do
     if Map.has_key?(data, :__struct__) do
       case data.__struct__ do
-        Ecto.Changeset -> extract_values(data)
-        value -> value
+        Ecto.Changeset -> extract_values(data, is_root)
+        _ -> data
       end
     else
       data
     end
   end
 
-  defp extract_values(changeset) do
+  defp extract_values(changeset, is_root) do
     if changeset.changes != %{} do
+      init = initial_value(changeset, is_root)
       changeset.changes
-      |> Enum.reduce(%{id: changeset.data.id}, fn({key, value}, accum) ->
+      |> Enum.reduce(init, fn({key, value}, accum) ->
         value = if is_list(value) do
-          Enum.map(value, &serialize_changes(&1))
+          Enum.map(value, &serialize_changes(&1, false))
           |> Enum.filter(fn(v) -> ! is_nil(v) end)
         else
-          serialize_changes(value)
+          serialize_changes(value, false)
         end
         Map.put(accum, key, value)
       end)
     end
   end
+
+  defp initial_value(_, true), do: %{}
+  defp initial_value(changeset, false), do: %{id: changeset.data.id}
 
   defp add_prefix(changeset, nil), do: changeset
   defp add_prefix(changeset, prefix), do: Ecto.put_meta(changeset, prefix: prefix)

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -308,25 +308,26 @@ defmodule PaperTrail do
   defp deep_serialize(data) do
     if Map.has_key?(data, :__struct__) do
       case data.__struct__ do
-        Ecto.Changeset ->
-          if data.changes != %{} do
-            data.changes
-            |> Enum.reduce(%{id: data.data.id}, fn({key, value}, accum) ->
-              value = if is_list(value) do
-                Enum.map(value, &serialize_changes(&1))
-                |> Enum.filter(fn(v) -> ! is_nil(v) end)
-              else
-                serialize_changes(value)
-              end
-
-              accum
-              |> Map.put(key, value)
-            end)
-          end
+        Ecto.Changeset -> extract_values(data)
         value -> value
       end
     else
       data
+    end
+  end
+
+  defp extract_values(changeset) do
+    if changeset.changes != %{} do
+      changeset.changes
+      |> Enum.reduce(%{id: changeset.data.id}, fn({key, value}, accum) ->
+        value = if is_list(value) do
+          Enum.map(value, &serialize_changes(&1))
+          |> Enum.filter(fn(v) -> ! is_nil(v) end)
+        else
+          serialize_changes(value)
+        end
+        Map.put(accum, key, value)
+      end)
     end
   end
 

--- a/test/support/simple_models.exs
+++ b/test/support/simple_models.exs
@@ -30,6 +30,13 @@ defmodule SimpleCompany do
     |> no_assoc_constraint(:people)
   end
 
+  def people_changeset(model, params \\ %{}) do
+    model
+    |> cast(params, @optional_fields)
+    |> cast_assoc(:people)
+    |> validate_required([:name])
+  end
+
   def count do
     from(record in __MODULE__, select: count(record.id)) |> PaperTrail.RepoClient.repo.one
   end


### PR DESCRIPTION
This PR splits the `deep_serialize` function (in charge to include relations in items_changes) in order to have a better readability. 